### PR TITLE
Fixed the undefined settings bug

### DIFF
--- a/src/services/persistence/persistence.js
+++ b/src/services/persistence/persistence.js
@@ -46,8 +46,28 @@ function settingsReducer(state = [], action) {
 
 let store;
 
+const initializeUndefinedSettings = (persistedState) => {
+    let settings = persistedState.settingsReducer;
+    if (settings === undefined) {
+        settings = {sortProperty: "name", sortOrder: "ascending", displayUnits: "imperial"}
+    }
+    else {
+        if (settings.sortProperty === undefined) {
+            settings.sortProperty = "name";
+        }
+        if (settings.sortOrder === undefined) {
+            settings.sortOrder = "ascending";
+        }
+        if (settings.displayUnits === undefined) {
+            settings.displayUnits = "imperial";
+        }
+    }
+    persistedState.settingsReducer = settings;
+}
+
 export const loadPersistedState = () => {
     const persistedState = loadState();
+    initializeUndefinedSettings(persistedState);
     const reducer = combineReducers({ placeReducer, settingsReducer });
     store = createStore(reducer, persistedState);
     store.subscribe(() => {


### PR DESCRIPTION
On the first run, if there are no persisted settings, changing display units to metric treats the original imperial unit temperatures as Celsius and then performs the F-C conversion. A refresh was needed to correct the display. The code mod sets all undefined settings to initial values so that when changing settings, the original settings value is known.